### PR TITLE
Fixed issue with NotifyPropertyChanged not firing.

### DIFF
--- a/src/ValidationRules/Validatable.cs
+++ b/src/ValidationRules/Validatable.cs
@@ -81,13 +81,14 @@ namespace Plugin.ValidationRules
             set 
             {
                 var oldValue = _value;
+                
+                SetProperty(ref _value, value);
 
                 if (Formatter != null)
                     ValueFormatted = Formatter.Format(value);
                 else
                     ValueFormatted = value;
 
-                SetProperty(ref _value, value);
                 ValueChanged?.Invoke(this, new ValueChangedEventArgs<T>() { OldValue = oldValue, NewValue = value });
             }
         }


### PR DESCRIPTION
Fixes issue #18 

Changes Proposed in this pull request:
- Moved up to call to "NotifyPropertyChanged" in the "Value"'s setter, as it was omitted because "ValueFormatted"'s setter would modify "Value"'s backing field before it had the chance to trigger the event.

### PR Checklist ###

- [ ] No tests (just a simple bug fix)
- [x] Rebased on top of master at time of PR
- [x] Consolidate commits as makes sense
