### PR TITLE
Fix valueChanged event firing twice

### DIFF
--- a/src/ValidationRules/Plugin.ValidationRules.csproj
+++ b/src/ValidationRules/Plugin.ValidationRules.csproj
@@ -7,7 +7,7 @@
 	<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Product>Plugin.ValidationRules</Product>
     <Copyright>Copyright 2021</Copyright>
-    <Version>1.5.0.0</Version>
+    <Version>1.5.0.1</Version>
     
     <!-- Package -->
     <PackageId>Plugin.ValidationRules</PackageId>
@@ -36,14 +36,14 @@ Improve the quality of your data using validation rules. Validation rules verify
 
     <!-- Assembly -->
     <RootNamespace>Plugin.ValidationRules</RootNamespace>
-    <AssemblyVersion>1.5.0.5</AssemblyVersion>
+    <AssemblyVersion>1.5.0.1</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <SignAssembly>false</SignAssembly>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>https://github.com/luismts/ValidationRulesPlugin/releases</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <FileVersion>1.4.0.1</FileVersion>
+    <FileVersion>1.5.0.1</FileVersion>
     
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/ValidationRules/Validatable.cs
+++ b/src/ValidationRules/Validatable.cs
@@ -81,14 +81,15 @@ namespace Plugin.ValidationRules
             set 
             {
                 var oldValue = _value;
-                
-                SetProperty(ref _value, value);
+                T valueFormatted;
 
                 if (Formatter != null)
-                    ValueFormatted = Formatter.Format(value);
+                    valueFormatted = Formatter.Format(value);
                 else
-                    ValueFormatted = value;
+                    valueFormatted = value;
 
+                SetProperty(ref _value, value);
+                SetProperty(ref _valueFormatted, valueFormatted);
                 ValueChanged?.Invoke(this, new ValueChangedEventArgs<T>() { OldValue = oldValue, NewValue = value });
             }
         }
@@ -116,6 +117,7 @@ namespace Plugin.ValidationRules
                     _value = value;
                 }
 
+                SetProperty(ref _value, value);
                 SetProperty(ref _valueFormatted, newValue);
                 ValueChanged?.Invoke(this, new ValueChangedEventArgs<T>() { OldValue = oldValue, NewValue = newValue });
             }


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes issue #21 

Changes Proposed in this pull request:
- Value and ValueFormatted are updating with backing fields now. 


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in the description)
- [x] Rebased on top of a master at the time of PR
- [x] Consolidate commits as makes sense
